### PR TITLE
【flink】set wrtierOperator parallelism when bact write and adaptive scheduler is open

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BucketingStreamPartitioner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BucketingStreamPartitioner.java
@@ -23,6 +23,9 @@ import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A {@link StreamPartitioner} which sends records from the same bucket to the same downstream
  * channel.
@@ -30,6 +33,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  * @param <T> type of record
  */
 public class BucketingStreamPartitioner<T> extends StreamPartitioner<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BucketingStreamPartitioner.class);
 
     private final ChannelComputer<T> channelComputer;
 
@@ -39,6 +44,7 @@ public class BucketingStreamPartitioner<T> extends StreamPartitioner<T> {
 
     @Override
     public void setup(int numberOfChannels) {
+        LOG.info("setup channel numbers:{}",numberOfChannels);
         super.setup(numberOfChannels);
         channelComputer.setup(numberOfChannels);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.flink.configuration.BatchExecutionOptions;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.paimon.CoreOptions.ChangelogProducer;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
 import org.apache.paimon.options.Options;
@@ -136,8 +138,8 @@ public abstract class FlinkSink<T> implements Serializable {
                                 WRITER_NAME + " -> " + table.name(),
                                 typeInfo,
                                 createWriteOperator(sinkProvider, isStreaming, commitUser))
-                        .setParallelism(input.getParallelism());
-
+                        .setParallelism( (!isStreaming && conf.get(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED)) ?
+                                conf.get(CoreOptions.DEFAULT_PARALLELISM) : input.getParallelism());
         SingleOutputStreamOperator<?> committed =
                 written.transform(
                                 GLOBAL_COMMITTER_NAME + " -> " + table.name(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.paimon.CoreOptions.ChangelogProducer;
+import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
@@ -137,9 +138,13 @@ public abstract class FlinkSink<T> implements Serializable {
                 input.transform(
                                 WRITER_NAME + " -> " + table.name(),
                                 typeInfo,
-                                createWriteOperator(sinkProvider, isStreaming, commitUser))
-                        .setParallelism( (!isStreaming && conf.get(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED)) ?
-                                conf.get(CoreOptions.DEFAULT_PARALLELISM) : input.getParallelism());
+                                createWriteOperator(sinkProvider, isStreaming, commitUser));
+
+        if(!isStreaming && table.options().get(FlinkConnectorOptions.SINK_PARALLELISM.key()) == null && conf.get(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED)){
+            written.setParallelism(conf.get(CoreOptions.DEFAULT_PARALLELISM));
+        }else {
+            written.setParallelism(input.getParallelism());
+        }
         SingleOutputStreamOperator<?> committed =
                 written.transform(
                                 GLOBAL_COMMITTER_NAME + " -> " + table.name(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataChannelComputer.java
@@ -23,9 +23,13 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.sink.KeyAndBucketExtractor;
 
 import org.apache.flink.table.data.RowData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** {@link ChannelComputer} for {@link RowData}. */
 public class RowDataChannelComputer implements ChannelComputer<RowData> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RowDataChannelComputer.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -42,6 +46,7 @@ public class RowDataChannelComputer implements ChannelComputer<RowData> {
 
     @Override
     public void setup(int numChannels) {
+        LOG.info("setup channel numbers:{}",numChannels);
         this.numChannels = numChannels;
         this.extractor = new RowDataKeyAndBucketExtractor(schema);
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- What is the purpose of the change, or the associated issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
