### PR TITLE
Add snapshot cleaning threshold.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -169,6 +169,7 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.snapshotNumRetainMin(),
                 options.snapshotNumRetainMax(),
                 options.snapshotTimeRetain().toMillis(),
+                options.snapshotCleanLimit(),
                 snapshotManager(),
                 newSnapshotDeletion(),
                 new TagFileKeeper(

--- a/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/CoreOptions.java
@@ -174,6 +174,12 @@ public class CoreOptions implements Serializable {
                     .defaultValue(Duration.ofHours(1))
                     .withDescription("The maximum time of completed snapshots to retain.");
 
+    public static final ConfigOption<Integer> SNAPSHOT_CLEAN_LIMIT =
+            key("snapshot.clean-limit")
+                    .intType()
+                    .defaultValue(200)
+                    .withDescription("The maximum quantity of snapshots to be cleared at once.");
+
     public static final ConfigOption<Duration> CONTINUOUS_DISCOVERY_INTERVAL =
             key("continuous.discovery-interval")
                     .durationType()
@@ -768,6 +774,10 @@ public class CoreOptions implements Serializable {
 
     public Duration snapshotTimeRetain() {
         return options.get(SNAPSHOT_TIME_RETAINED);
+    }
+
+    public Integer snapshotCleanLimit() {
+        return options.get(SNAPSHOT_CLEAN_LIMIT);
     }
 
     public int manifestMergeMinCount() {

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -132,10 +132,12 @@ public class TestFileStore extends KeyValueFileStore {
 
     public FileStoreExpireImpl newExpire(
             int numRetainedMin, int numRetainedMax, long millisRetained) {
+        int cleanLimit = options.snapshotCleanLimit();
         return new FileStoreExpireImpl(
                 numRetainedMin,
                 numRetainedMax,
                 millisRetained,
+                cleanLimit,
                 snapshotManager(),
                 newSnapshotDeletion(),
                 new TagFileKeeper(


### PR DESCRIPTION
Add snapshot cleaning restrictions to avoid deleting too many snapshots at once, which may block the checkpoint and cause a timeout.