### PR TITLE
Tc paimon 0.9 compatible spark3.4 timestamp 

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -88,5 +88,6 @@ public class SparkConnectorOptions {
                     .withDescription(
                             "When false, the default is to follow the historical version method. "
                                     + "LocalZonedTimestamp and TimestampType are converted to "
-                                    + "Spark's TimestampType. Otherwise, the new version method is used.");
+                                    + "Spark's TimestampType. Otherwise, the new version method is used."
+                                    + "The default value is true");
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark;
 
+import org.apache.paimon.annotation.Documentation;
 import org.apache.paimon.options.ConfigOption;
 
 import static org.apache.paimon.options.ConfigOptions.key;
@@ -77,4 +78,15 @@ public class SparkConnectorOptions {
                     .defaultValue(false)
                     .withDescription(
                             "Whether to read row in the form of changelog (add rowkind column in row to represent its change type).");
+
+    @Documentation.ExcludeFromDocumentation(
+            "In Spark >= 3.4, does Paimon's TimestampType type conversion use the old version method by default")
+    public static final ConfigOption<Boolean> PAIMON_INFER_TIMESTAMP_NTZ_ENABLED =
+            key("spark.sql.paimon.inferTimestampNTZ.enabled")
+                    .booleanType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "When false, the default is to follow the historical version method. "
+                                    + "LocalZonedTimestamp and TimestampType are converted to "
+                                    + "Spark's TimestampType. Otherwise, the new version method is used.");
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
@@ -18,7 +18,16 @@
 
 package org.apache.paimon.spark.util.shim
 
+import org.apache.paimon.spark.SparkConnectorOptions
+
+import org.apache.spark.SparkEnv
+
 object TypeUtils {
 
-  def treatPaimonTimestampTypeAsSparkTimestampType(): Boolean = false
+  def treatPaimonTimestampTypeAsSparkTimestampType(): Boolean = {
+    !SparkEnv.get.conf
+      .getOption(SparkConnectorOptions.PAIMON_INFER_TIMESTAMP_NTZ_ENABLED.key())
+      .getOrElse("true")
+      .toBoolean
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This PR is for compatibility with versions of Spark prior to 3.4 concerning the conversion of TimestampType:
In historical versions, due to both Paimon's TimestampType and LocalZonedTimestamp being converted to Spark's TimestampType, many of our Paimon table field attributes were set to TimestampType. However, when we attempted to upgrade to Spark 3.4, the reading of these tables was converted to Spark's TimestampNTZType. This has caused discrepancies in timestamp type data in terms of time zones in our business data. Therefore, we hope to accommodate this issue through configurations added during Spark execution.
### Tests
test sql：
The gmt_canceled field type of the paimon table paimon.test_db.test_timestamp_001 is timestamp

`SELECT gmt_canceled_time,  to_timestamp(gmt_canceled_timestamp) actual_time FROM (
  SELECT 
t1.gmt_canceled as gmt_canceled_time,
unix_timestamp(t1.gmt_canceled) as gmt_canceled_timestamp
 FROM  paimon.test_db.test_timestamp_001 as t1
) tab1 limit 10`
Before Repair：
![image](https://github.com/user-attachments/assets/95de2acd-3ab2-4e4e-a475-a90c25f93ba9)
The timestamp read by spark3.4 differs from the actual time by 8 hours

After Repair：
The read time is consistent with the real time
![image](https://github.com/user-attachments/assets/ab27e4b5-c70c-4bdb-b8a8-364c9d81fd47)

When submitting a spark job, you need to add: --conf spark.sql.paimon.inferTimestampNTZ.enabled=false

### API and Format

no

### Documentation

no
